### PR TITLE
add precision=12, scale=2

### DIFF
--- a/target_mysql/sinks.py
+++ b/target_mysql/sinks.py
@@ -202,7 +202,7 @@ class MySQLConnector(SQLConnector):
 
         if self._jsonschema_type_check(jsonschema_type, ("number",)):
             if 'multipleOf' in jsonschema_type:
-                return cast(sqlalchemy.types.TypeEngine, mysql.DECIMAL())
+                return cast(sqlalchemy.types.TypeEngine, mysql.DECIMAL(precision=12, scale=2))
             else:
                 return cast(sqlalchemy.types.TypeEngine, mysql.FLOAT())
 


### PR DESCRIPTION
Currently number format was without specific precision or scale. Adding default:
```
precision=12, scale=2
```